### PR TITLE
Be more lax about token time limit

### DIFF
--- a/lib/passport-mediawiki-oauth/oauth.js
+++ b/lib/passport-mediawiki-oauth/oauth.js
@@ -143,10 +143,11 @@ Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
             // Verify we are within the time limits of the token.
             // Issued at (iat) should be in the past
             var now = Math.round((new Date()).getTime() / 1000);
-            if (parseInt(identification.iat, 10) > now){
+            // (Allow at least 1 second either side)
+            if (parseInt(identification.iat, 10) - 1 >= now + 1){
                 throw new InternalOAuthError('JSON Web Token Validation Problem, iat');
             }
-            
+
             // Expiration (exp) should be in the future
             if (parseInt(identification.exp, 10) < now){
                 throw new InternalOAuthError('JSON Web Token Validation Problem, exp');


### PR DESCRIPTION
While testing locally against MediaWiki, I found on various occasions
this test failed, as the token was not completely in sync with my
local time (maybe an issue with my/MediaWiki's clock)

Allowing 1 second either side of the token removed all these problems.
I don't know enough about the oauth spec to know if this will be an
issue but it was causing me a lot of headaches during development at
the hackathon!