### PR TITLE
Update link to repository and issue tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "keywords": ["passport", "mediawiki", "auth", "authn", "authentication", "identity"],
   "repository": {
     "type": "git",
-    "url": "https://git.wikimedia.org/git/passport-mediawiki.git"
+    "url": "https://github.com/milimetric/passport-mediawiki-oauth.git"
   },
   "bugs": {
-    "url": "https://bugzilla.wikimedia.org/"
+    "url": "https://github.com/milimetric/passport-mediawiki-oauth/issues"
   },
   "author": {
     "name": "Dan Andreescu"


### PR DESCRIPTION
As described at <https://phabricator.wikimedia.org/T210771> the previous
repository location does not exist anymore. The issue tracker is
outdated as well and it should give a more specific URL than
<https://phabricator.wikimedia.org/>.